### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "require": {
         "php": ">=7.3 | ^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3|^7.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0"
+        "guzzlehttp/guzzle": "^6.3|^7.0|^7.5",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
Downgrade packages for POPS2020

We still need support for laravel 6.
